### PR TITLE
feat: query api like gorm

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/stretchr/testify v1.8.1
 	google.golang.org/grpc v1.53.0
 	google.golang.org/protobuf v1.28.1
+	github.com/DATA-DOG/go-sqlmock v1.5.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7O
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
+github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/GreptimeTeam/greptime-proto v0.0.0-20230215071017-36147379c3fd h1:Vc9MXBDMih9E+EvFLJHQDOsdh9PwBrUDiza3PKB7brc=
 github.com/GreptimeTeam/greptime-proto v0.0.0-20230215071017-36147379c3fd/go.mod h1:jk5XBR9qIbSBiDF2Gix1KALyIMCVktcpx91AayOWxmE=
 github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VMrpA=
@@ -73,6 +75,8 @@ github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
+github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
+github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
@@ -283,6 +287,7 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.4/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/request/query.go
+++ b/pkg/request/query.go
@@ -1,6 +1,10 @@
 package request
 
 import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"reflect"
 	"strings"
 
 	greptime "github.com/GreptimeTeam/greptime-proto/go/greptime/v1"
@@ -47,3 +51,113 @@ func (r *QueryRequest) Build() (*greptime.GreptimeRequest, error) {
 		Request: query,
 	}, nil
 }
+
+// func Query(db *sql.DB, sql string, dest any) error {
+// 	typ := reflect.TypeOf(dest)
+// 	value := reflect.ValueOf(dest)
+// 	if typ.Kind() != reflect.Pointer {
+// 		return errors.New("dest should be a pointer")
+// 	}
+// 	if typ.Elem().Kind() != reflect.Slice {
+// 		return errors.New("dest should point to a slice so far")
+// 	}
+// 	if !value.IsZero() {
+// 		return errors.New("dest should point to an empty slice so far")
+// 	}
+
+// 	if db == nil {
+// 		return errors.New("db should not be empty")
+// 	}
+// 	res, err := db.Query(sql)
+// 	if err != nil {
+// 		fmt.Printf("db.Query err: %v", err)
+// 	}
+
+// 	elemType := typ.Elem()
+// 	array := dest.([]any)
+
+// 	for res.Next() {
+// 		// the pointer to a `monitor` in zero
+// 		row := reflect.New(elemType)
+
+// 		data := make([]any, row.NumField(), row.NumField())
+
+// 		err := res.Scan(data)
+// 		if err != nil {
+// 			fmt.Printf("res.Scan err: %v", err)
+// 			continue
+// 		}
+// 		array := append(array, )
+// 	}
+
+// }
+
+func fillStructSlice(slicePtr interface{}, rows *sql.Rows) error {
+	// Check that the first input is a pointer to a slice
+	sliceValue := reflect.ValueOf(slicePtr)
+	if sliceValue.Kind() != reflect.Ptr {
+		return errors.New("first argument must be a pointer to a slice")
+	}
+	sliceElem := sliceValue.Elem()
+	if sliceElem.Kind() != reflect.Slice {
+		return errors.New("first argument must be a pointer to a slice")
+	}
+
+	// Get the type of the slice elements
+	elemType := sliceElem.Type().Elem()
+
+	// Iterate over the rows and create a new struct for each row
+	for rows.Next() {
+		// Create a new struct instance
+		structValue := reflect.New(elemType).Elem()
+
+		// Get the row data and make sure it has the right number of columns
+		rowData := make([]interface{}, structValue.NumField())
+		// Iterate over the fields and create pointers to the field values
+		for i := 0; i < structValue.NumField(); i++ {
+			rowData[i] = structValue.Field(i).Addr().Interface()
+		}
+		if err := rows.Scan(rowData...); err != nil {
+			return err
+		}
+		if len(rowData) != structValue.NumField() {
+			return fmt.Errorf("incorrect number of columns for row: expected %d, got %d", structValue.NumField(), len(rowData))
+		}
+
+		// Set the values of the struct fields from the row data
+		for i := 0; i < structValue.NumField(); i++ {
+			fieldValue := structValue.Field(i)
+			if !fieldValue.CanSet() {
+				return fmt.Errorf("field %s is not settable", elemType.Field(i).Name)
+			}
+			value := reflect.ValueOf(rowData[i]).Elem()
+			if !value.IsValid() {
+				continue
+			}
+			if value.Kind() == reflect.Ptr {
+				if value.IsNil() {
+					continue
+				}
+				value = value.Elem()
+			}
+			// if value.Kind() != fieldValue.Kind() {
+			// 	return fmt.Errorf("incorrect type for field %s: expected %s, got %s", elemType.Field(i).Name, fieldValue.Kind(), value.Elem().Kind())
+			// }
+			if !value.Type().AssignableTo(fieldValue.Type()) {
+				return fmt.Errorf("incorrect type for field %s: expected %s, got %s", elemType.Field(i).Name, fieldValue.Type(), value.Type())
+			}
+			fieldValue.Set(value)
+		}
+
+		// Append the new struct to the slice
+		sliceElem.Set(reflect.Append(sliceElem, structValue))
+	}
+
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+

--- a/pkg/request/query.go
+++ b/pkg/request/query.go
@@ -52,47 +52,22 @@ func (r *QueryRequest) Build() (*greptime.GreptimeRequest, error) {
 	}, nil
 }
 
-// func Query(db *sql.DB, sql string, dest any) error {
-// 	typ := reflect.TypeOf(dest)
-// 	value := reflect.ValueOf(dest)
-// 	if typ.Kind() != reflect.Pointer {
-// 		return errors.New("dest should be a pointer")
-// 	}
-// 	if typ.Elem().Kind() != reflect.Slice {
-// 		return errors.New("dest should point to a slice so far")
-// 	}
-// 	if !value.IsZero() {
-// 		return errors.New("dest should point to an empty slice so far")
-// 	}
-
-// 	if db == nil {
-// 		return errors.New("db should not be empty")
-// 	}
-// 	res, err := db.Query(sql)
-// 	if err != nil {
-// 		fmt.Printf("db.Query err: %v", err)
-// 	}
-
-// 	elemType := typ.Elem()
-// 	array := dest.([]any)
-
-// 	for res.Next() {
-// 		// the pointer to a `monitor` in zero
-// 		row := reflect.New(elemType)
-
-// 		data := make([]any, row.NumField(), row.NumField())
-
-// 		err := res.Scan(data)
-// 		if err != nil {
-// 			fmt.Printf("res.Scan err: %v", err)
-// 			continue
-// 		}
-// 		array := append(array, )
-// 	}
-
-// }
+func Query(db *sql.DB, sql string, dest any) error {
+	if db == nil {
+		return ErrEmptyDatabase
+	}
+	rows, err := db.Query(sql)
+	if err != nil {
+		return err
+	}
+	return fillStructSlice(dest, rows)
+}
 
 func fillStructSlice(dest interface{}, rows *sql.Rows) error {
+	if rows == nil {
+		return errors.New("rows should not be empty")
+	}
+
 	// check if the dest can be set
 	err := isStructSliceSettable(dest)
 	if err != nil {

--- a/pkg/request/query_test.go
+++ b/pkg/request/query_test.go
@@ -28,14 +28,59 @@ func TestFillStructSliceFromRows(t *testing.T) {
 	}
 
 	// Set up a mock rows object
-	columns := []string{"name", "age"}
-	rows := sqlmock.NewRows(columns).
+	rows := sqlmock.NewRows([]string{"name", "age"}).
 		AddRow("Alice", 25).
 		AddRow("Bob", 30).
 		AddRow("Charlie", 35)
 
+	// Call the function and check the result
 	slice := []Person{}
 	err := fillStructSlice(&slice, mockRowsToSqlRows(rows))
 	assert.Nil(t, err)
 	assert.Equal(t, slice, expected)
+}
+
+func TestFillStructSliceWithInvalidRowData(t *testing.T) {
+	rows := sqlmock.NewRows([]string{"name", "age"}).
+		AddRow("test", 123.345)
+	slice := []Person{}
+	err := fillStructSlice(&slice, mockRowsToSqlRows(rows))
+	// fmt.Printf("rows: %+v", slice)
+	assert.NotNil(t, err)
+}
+
+func TestFillStructSliceWithIncorrectNumberOfColumns(t *testing.T) {
+	// TODO(vinland-avalon): a better way to mock, since sqlmock need column number to match
+	// rows := sqlmock.NewRows([]string{"id", "name"}).
+	// 	AddRow(1).
+	// 	AddRow(2, "test2")
+	// var slice []struct {
+	// 	Id   int
+	// 	Name string
+	// }
+	// err := fillStructSlice(&slice, mockRowsToSqlRows(rows))
+}
+
+func TestIsStructSliceSettableWithNilSlicePointer(t *testing.T) {
+	err := isStructSliceSettable(nil)
+	assert.NotNil(t, err)
+	assert.Equal(t, "dest must be a pointer to a slice", err.Error())
+}
+
+func TestIsStructSliceSettableWithNonPointerSlice(t *testing.T) {
+	slice := make([]Person, 0)
+	err := isStructSliceSettable(slice)
+	assert.NotNil(t, err)
+	assert.Equal(t, "dest must be a pointer to a slice", err.Error())
+}
+
+func TestIsStructSliceSettableWithFieldCanNotSet(t *testing.T) {
+	type NonSettableStruct struct {
+		ptr int
+	}
+
+	slice := []NonSettableStruct{}
+	err := isStructSliceSettable(&slice)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "is not settable")
 }

--- a/pkg/request/query_test.go
+++ b/pkg/request/query_test.go
@@ -1,0 +1,41 @@
+package request
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+)
+
+func mockRowsToSqlRows(mockRows *sqlmock.Rows) *sql.Rows {
+	db, mock, _ := sqlmock.New()
+	mock.ExpectQuery("select").WillReturnRows(mockRows)
+	rows, _ := db.Query("select")
+	return rows
+}
+
+type Person struct {
+	Name string
+	Age  int
+}
+
+func TestFillStructSliceFromRows(t *testing.T) {
+	expected := []Person{
+		{"Alice", 25},
+		{"Bob", 30},
+		{"Charlie", 35},
+	}
+
+	// Set up a mock rows object
+	columns := []string{"name", "age"}
+	rows := sqlmock.NewRows(columns).
+		AddRow("Alice", 25).
+		AddRow("Bob", 30).
+		AddRow("Charlie", 35)
+
+	slice := []Person{}
+	err := fillStructSlice(&slice, mockRowsToSqlRows(rows))
+	assert.Nil(t, err)
+	assert.Equal(t, slice, expected)
+}

--- a/test/insert_query_test.go
+++ b/test/insert_query_test.go
@@ -30,10 +30,10 @@ var (
 )
 
 type weather struct {
-	city        string
-	temperature float64
-	moisture    float64
-	ts          time.Time
+	City        string
+	Temperature float64
+	Moisture    float64
+	Ts          time.Time
 }
 
 func init() {
@@ -89,16 +89,16 @@ func init() {
 func TestBasicWorkFlow(t *testing.T) {
 	originWeathers := []weather{
 		{
-			city:        "Beijing",
-			ts:          time.UnixMilli(1677728740000),
-			temperature: 22.0,
-			moisture:    0.45,
+			City:        "Beijing",
+			Ts:          time.UnixMilli(1677728740000),
+			Temperature: 22.0,
+			Moisture:    0.45,
 		},
 		{
-			city:        "Shanghai",
-			ts:          time.UnixMilli(1677728740012),
-			temperature: 28.0,
-			moisture:    0.80,
+			City:        "Shanghai",
+			Ts:          time.UnixMilli(1677728740012),
+			Temperature: 28.0,
+			Moisture:    0.80,
 		},
 	}
 	// Insert
@@ -113,10 +113,10 @@ func TestBasicWorkFlow(t *testing.T) {
 	metric := request.Metric{}
 	for _, originWeather := range originWeathers {
 		series := request.Series{}
-		series.AddTag("city", originWeather.city)
-		series.SetTimeWithKey("ts", originWeather.ts)
-		series.AddField("temperature", originWeather.temperature)
-		series.AddField("moisture", originWeather.moisture)
+		series.AddTag("city", originWeather.City)
+		series.SetTimeWithKey("ts", originWeather.Ts)
+		series.AddField("temperature", originWeather.Temperature)
+		series.AddField("moisture", originWeather.Moisture)
 		metric.AddSeries(series)
 	}
 
@@ -140,12 +140,18 @@ func TestBasicWorkFlow(t *testing.T) {
 	var actuallWeathers []weather
 	for res.Next() {
 		var actuallWeather weather
-		err = res.Scan(&actuallWeather.city, &actuallWeather.temperature,
-			&actuallWeather.moisture, &actuallWeather.ts)
+		err = res.Scan(&actuallWeather.City, &actuallWeather.Temperature,
+			&actuallWeather.Moisture, &actuallWeather.Ts)
 		assert.Nil(t, err)
 		actuallWeathers = append(actuallWeathers, actuallWeather)
 	}
 
 	assert.Nil(t, err)
 	assert.Equal(t, originWeathers, actuallWeathers)
+
+	// Query with slice
+	actualWeathers2 := []weather{}
+	err = request.Query(db, "SELECT * FROM weather", &actualWeathers2)
+	assert.Nil(t, err)
+	assert.Equal(t, originWeathers, actualWeathers2)
 }


### PR DESCRIPTION
## What's changed and what's your intention?

Provide a new user API for Query, which is like `gorm`. I mean, pass a pointer of slice to query and then fill it up with data.

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- No breaking changes to existed code.
- The Query API is in `request` package so far.
- There are some limitations on the param `dest`, need a doc.

## Checklist

- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link

#35 