### PR TITLE
refactor: unary calls and stream calls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/GreptimeTeam/greptimedb-client-go
 go 1.19
 
 require (
-	github.com/GreptimeTeam/greptime-proto v0.0.0-20230320132358-eb760d219206
+	github.com/GreptimeTeam/greptime-proto v0.0.0-20230324013738-9eaf95eb91a0
 	github.com/apache/arrow/go/arrow v0.0.0-20211112161151-bc219186db40
 	github.com/bits-and-blooms/bitset v1.5.0
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/GreptimeTeam/greptime-proto v0.0.0-20230320132358-eb760d219206 h1:CfDD7Jw8QPT4wa77kLphS5N59KRff8vg8zmzaVhXbWw=
 github.com/GreptimeTeam/greptime-proto v0.0.0-20230320132358-eb760d219206/go.mod h1:jk5XBR9qIbSBiDF2Gix1KALyIMCVktcpx91AayOWxmE=
+github.com/GreptimeTeam/greptime-proto v0.0.0-20230324013738-9eaf95eb91a0 h1:lWODYFSSrGdjJIWWfvjdbM6kATmzksF6U7yVkyvL618=
+github.com/GreptimeTeam/greptime-proto v0.0.0-20230324013738-9eaf95eb91a0/go.mod h1:jk5XBR9qIbSBiDF2Gix1KALyIMCVktcpx91AayOWxmE=
 github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VMrpA=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=

--- a/pkg/request/client.go
+++ b/pkg/request/client.go
@@ -55,8 +55,8 @@ func (c *Client) Insert(ctx context.Context, req InsertRequest) (*greptime.Affec
 	return response.GetAffectedRows(), nil
 }
 
-func (c *Client) InitStreamClient(ctx context.Context) (*StreamClient, error) {
-	client, err := c.DatabaseClient.HandleRequests(ctx, grpc.EmptyCallOption{})
+func (c *Client) InitStreamClient(ctx context.Context, opts ...grpc.CallOption) (*StreamClient, error) {
+	client, err := c.DatabaseClient.HandleRequests(ctx, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/request/config.go
+++ b/pkg/request/config.go
@@ -2,6 +2,8 @@ package request
 
 import (
 	"google.golang.org/grpc"
+
+	greptime "github.com/GreptimeTeam/greptime-proto/go/greptime/v1"
 )
 
 type Config struct {
@@ -46,4 +48,20 @@ func (c *Config) WithDialOptions(options ...grpc.DialOption) *Config {
 	c.DialOptions = append(c.DialOptions, options...)
 
 	return c
+}
+
+// so far, only support `Basic`, `Token` is not implemented
+func (c *Config) buildAuth() *greptime.AuthHeader {
+	if len(c.UserName) == 0 {
+		return nil
+	} else {
+		return &greptime.AuthHeader{
+			AuthScheme: &greptime.AuthHeader_Basic{
+				Basic: &greptime.Basic{
+					Username: c.UserName,
+					Password: c.Password,
+				},
+			},
+		}
+	}
 }

--- a/pkg/request/stream_client.go
+++ b/pkg/request/stream_client.go
@@ -1,0 +1,31 @@
+package request
+
+import (
+	"context"
+
+	greptime "github.com/GreptimeTeam/greptime-proto/go/greptime/v1"
+)
+
+type StreamClient struct {
+	client greptime.GreptimeDatabase_HandleRequestsClient
+	cfg    *Config
+}
+
+func (c *StreamClient) Send(ctx context.Context, req InsertRequest) error {
+	request, err := req.Build()
+	if err != nil {
+		return err
+	}
+	request.Header.Authorization = c.cfg.buildAuth()
+
+	return c.client.Send(request)
+}
+
+func (c *StreamClient) CloseAndRecv(ctx context.Context) (*greptime.AffectedRows, error) {
+	resp, err := c.client.CloseAndRecv()
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.GetAffectedRows(), nil
+}


### PR DESCRIPTION
## What's changed and what's your intention?

The GreptimeDB gRPC now support unary calls as well as stream calls for insert.
So, we can replace `do_get` with `unary calls`
Also, we'd like to provide users with stream calls for better performance.

## Checklist

- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
#50 