### PR TITLE
feat: default catalog and database

### DIFF
--- a/pkg/request/client.go
+++ b/pkg/request/client.go
@@ -41,7 +41,7 @@ func NewClient(cfg *Config) (*Client, error) {
 }
 
 func (c *Client) Insert(ctx context.Context, req InsertRequest) (*greptime.AffectedRows, error) {
-	request, err := req.Build()
+	request, err := req.Build(c.Cfg.Catalog, c.Cfg.Database)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +71,7 @@ func (c *Client) InitStreamClient(ctx context.Context, opts ...grpc.CallOption) 
 // reader, err := client.Query(ctx, req)
 // defer reader.Release()
 func (c *Client) Query(ctx context.Context, req QueryRequest) (*flight.Reader, error) {
-	request, err := req.Build()
+	request, err := req.Build(c.Cfg.Catalog, c.Cfg.Database)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func (c *Client) Query(ctx context.Context, req QueryRequest) (*flight.Reader, e
 
 // Query data from greptimedb via SQL.
 func (c *Client) QueryMetric(ctx context.Context, req QueryRequest) (*Metric, error) {
-	request, err := req.Build()
+	request, err := req.Build(c.Cfg.Catalog, c.Cfg.Database)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/request/client.go
+++ b/pkg/request/client.go
@@ -41,11 +41,10 @@ func NewClient(cfg *Config) (*Client, error) {
 }
 
 func (c *Client) Insert(ctx context.Context, req InsertRequest) (*greptime.AffectedRows, error) {
-	request, err := req.Build(c.Cfg.Catalog, c.Cfg.Database)
+	request, err := req.Build(c.Cfg)
 	if err != nil {
 		return nil, err
 	}
-	request.Header.Authorization = c.Cfg.buildAuth()
 
 	response, err := c.DatabaseClient.Handle(ctx, request)
 	if err != nil {
@@ -71,11 +70,10 @@ func (c *Client) InitStreamClient(ctx context.Context, opts ...grpc.CallOption) 
 // reader, err := client.Query(ctx, req)
 // defer reader.Release()
 func (c *Client) Query(ctx context.Context, req QueryRequest) (*flight.Reader, error) {
-	request, err := req.Build(c.Cfg.Catalog, c.Cfg.Database)
+	request, err := req.Build(c.Cfg)
 	if err != nil {
 		return nil, err
 	}
-	request.Header.Authorization = c.Cfg.buildAuth()
 
 	b, err := proto.Marshal(request)
 	if err != nil {
@@ -98,11 +96,10 @@ func (c *Client) Query(ctx context.Context, req QueryRequest) (*flight.Reader, e
 
 // Query data from greptimedb via SQL.
 func (c *Client) QueryMetric(ctx context.Context, req QueryRequest) (*Metric, error) {
-	request, err := req.Build(c.Cfg.Catalog, c.Cfg.Database)
+	request, err := req.Build(c.Cfg)
 	if err != nil {
 		return nil, err
 	}
-	request.Header.Authorization = c.Cfg.buildAuth()
 
 	b, err := proto.Marshal(request)
 	if err != nil {

--- a/pkg/request/header.go
+++ b/pkg/request/header.go
@@ -17,23 +17,25 @@ func (h *Header) WithDatabase(database string) *Header {
 	return h
 }
 
-func (h *Header) buildRequestHeader(catalog, database string) (*greptime.RequestHeader, error) {
+func (h *Header) buildRequestHeader(cfg *Config) (*greptime.RequestHeader, error) {
 	header := &greptime.RequestHeader{
 		Catalog: h.Catalog,
 		Schema:  h.Database,
 	}
 
-	if IsEmptyString(header.Catalog) && !IsEmptyString(catalog) {
-		header.Catalog = catalog
+	if IsEmptyString(header.Catalog) && !IsEmptyString(cfg.Catalog) {
+		header.Catalog = cfg.Catalog
 	}
 
 	if IsEmptyString(header.Schema) {
-		if IsEmptyString(database) {
+		if IsEmptyString(cfg.Database) {
 			return nil, ErrEmptyDatabase
 		} else {
-			header.Schema = database
+			header.Schema = cfg.Database
 		}
 	}
+
+	header.Authorization = cfg.buildAuth()
 
 	return header, nil
 }

--- a/pkg/request/header.go
+++ b/pkg/request/header.go
@@ -1,6 +1,6 @@
 package request
 
-import "strings"
+import greptime "github.com/GreptimeTeam/greptime-proto/go/greptime/v1"
 
 type Header struct {
 	Catalog  string // optional
@@ -18,9 +18,26 @@ func (h *Header) WithDatabase(database string) *Header {
 }
 
 func (h *Header) IsDatabaseEmpty() bool {
-	return len(strings.TrimSpace(h.Database)) == 0
+	return IsEmptyString(h.Database)
 }
 
-func (h *Header) IsTableEmpty() bool {
-	return len(strings.TrimSpace(h.Database)) == 0
+func (h *Header) buildRequestHeader(catalog, database string) (*greptime.RequestHeader, error) {
+	header := &greptime.RequestHeader{
+		Catalog: h.Catalog,
+		Schema:  h.Database,
+	}
+
+	if IsEmptyString(header.Catalog) && !IsEmptyString(catalog) {
+		header.Catalog = catalog
+	}
+
+	if IsEmptyString(header.Schema) {
+		if IsEmptyString(database) {
+			return nil, ErrEmptyDatabase
+		} else {
+			header.Schema = database
+		}
+	}
+
+	return header, nil
 }

--- a/pkg/request/header.go
+++ b/pkg/request/header.go
@@ -17,10 +17,6 @@ func (h *Header) WithDatabase(database string) *Header {
 	return h
 }
 
-func (h *Header) IsDatabaseEmpty() bool {
-	return IsEmptyString(h.Database)
-}
-
 func (h *Header) buildRequestHeader(catalog, database string) (*greptime.RequestHeader, error) {
 	header := &greptime.RequestHeader{
 		Catalog: h.Catalog,

--- a/pkg/request/header_test.go
+++ b/pkg/request/header_test.go
@@ -11,22 +11,22 @@ import (
 func TestHeaderBuild(t *testing.T) {
 	h := &Header{}
 
-	gh, err := h.buildRequestHeader("", "")
+	gh, err := h.buildRequestHeader(&Config{})
 	assert.ErrorIs(t, err, ErrEmptyDatabase)
 	assert.Nil(t, gh)
 
-	gh, err = h.buildRequestHeader("catalog", "database")
+	gh, err = h.buildRequestHeader(&Config{Catalog: "catalog", Database: "database"})
 	assert.Nil(t, err)
 	assert.Equal(t, &greptime.RequestHeader{
 		Catalog: "catalog",
-		Schema: "database",
+		Schema:  "database",
 	}, gh)
-	
+
 	h.WithCatalog("a").WithDatabase("b")
-	gh, err = h.buildRequestHeader("catalog", "database")
+	gh, err = h.buildRequestHeader(&Config{Catalog: "catalog", Database: "database"})
 	assert.Nil(t, err)
 	assert.Equal(t, &greptime.RequestHeader{
 		Catalog: "a",
-		Schema: "b",
+		Schema:  "b",
 	}, gh)
 }

--- a/pkg/request/header_test.go
+++ b/pkg/request/header_test.go
@@ -1,0 +1,32 @@
+package request
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	greptime "github.com/GreptimeTeam/greptime-proto/go/greptime/v1"
+)
+
+func TestHeaderBuild(t *testing.T) {
+	h := &Header{}
+
+	gh, err := h.buildRequestHeader("", "")
+	assert.ErrorIs(t, err, ErrEmptyDatabase)
+	assert.Nil(t, gh)
+
+	gh, err = h.buildRequestHeader("catalog", "database")
+	assert.Nil(t, err)
+	assert.Equal(t, &greptime.RequestHeader{
+		Catalog: "catalog",
+		Schema: "database",
+	}, gh)
+	
+	h.WithCatalog("a").WithDatabase("b")
+	gh, err = h.buildRequestHeader("catalog", "database")
+	assert.Nil(t, err)
+	assert.Equal(t, &greptime.RequestHeader{
+		Catalog: "a",
+		Schema: "b",
+	}, gh)
+}

--- a/pkg/request/insert.go
+++ b/pkg/request/insert.go
@@ -24,12 +24,12 @@ func (r *InsertRequest) RowCount() uint32 {
 	return uint32(len(r.Metric.series))
 }
 
-func (r *InsertRequest) Build(catalog, database string) (*greptime.GreptimeRequest, error) {
-	header, err := r.Header.buildRequestHeader(catalog, database)
+func (r *InsertRequest) Build(cfg *Config) (*greptime.GreptimeRequest, error) {
+	header, err := r.Header.buildRequestHeader(cfg)
 	if err != nil {
 		return nil, err
 	}
-	
+
 	if IsEmptyString(r.Table) {
 		return nil, ErrEmptyTable
 	}

--- a/pkg/request/insert_query_test.go
+++ b/pkg/request/insert_query_test.go
@@ -501,26 +501,6 @@ func TestNilInColumn(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestInsertRequestBuild(t *testing.T) {
-	r := InsertRequest{}
-	// empty database
-	req, err := r.Build()
-	assert.Equal(t, ErrEmptyDatabase, err)
-	assert.Nil(t, req)
-
-	// empty table
-	r.Database = "public"
-	req, err = r.Build()
-	assert.Equal(t, ErrEmptyTable, err)
-	assert.Nil(t, req)
-
-	// empty series
-	r.WithTable("monitor")
-	req, err = r.Build()
-	assert.Equal(t, ErrNoSeriesInMetric, err)
-	assert.Nil(t, req)
-}
-
 func TestNoNeedAuth(t *testing.T) {
 	grpcAddr := DockerTestInit(DefaultDockerTestConfig())
 	options := []grpc.DialOption{

--- a/pkg/request/query.go
+++ b/pkg/request/query.go
@@ -31,8 +31,8 @@ func (r *QueryRequest) IsPromQLEmpty() bool {
 	return r.promQL == nil
 }
 
-func (r *QueryRequest) Build(catalog, database string) (*greptime.GreptimeRequest, error) {
-	header, err := r.Header.buildRequestHeader(catalog, database)
+func (r *QueryRequest) Build(cfg *Config) (*greptime.GreptimeRequest, error) {
+	header, err := r.Header.buildRequestHeader(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/request/query.go
+++ b/pkg/request/query.go
@@ -31,14 +31,10 @@ func (r *QueryRequest) IsPromQLEmpty() bool {
 	return r.promQL == nil
 }
 
-func (r *QueryRequest) Build() (*greptime.GreptimeRequest, error) {
-	if r.IsDatabaseEmpty() {
-		return nil, ErrEmptyDatabase
-	}
-
-	header := &greptime.RequestHeader{
-		Catalog: r.Catalog,
-		Schema:  r.Database,
+func (r *QueryRequest) Build(catalog, database string) (*greptime.GreptimeRequest, error) {
+	header, err := r.Header.buildRequestHeader(catalog, database)
+	if err != nil {
+		return nil, err
 	}
 
 	request := &greptime.GreptimeRequest_Query{

--- a/pkg/request/request_test.go
+++ b/pkg/request/request_test.go
@@ -8,17 +8,17 @@ import (
 
 func TestQueryBuilder(t *testing.T) {
 	rb := &QueryRequest{}
-	request, err := rb.Build("", "")
+	request, err := rb.Build(&Config{})
 	assert.Nil(t, request)
 	assert.ErrorIs(t, err, ErrEmptyDatabase)
 
 	rb.WithDatabase("disk_usage")
-	request, err = rb.Build("", "")
+	request, err = rb.Build(&Config{})
 	assert.Nil(t, request)
 	assert.ErrorIs(t, err, ErrEmptyQuery)
 
 	rb.WithSql("select * from monitor")
-	request, err = rb.Build("", "")
+	request, err = rb.Build(&Config{})
 	assert.NotNil(t, request)
 	assert.Nil(t, err)
 }
@@ -26,19 +26,19 @@ func TestQueryBuilder(t *testing.T) {
 func TestInsertBuilder(t *testing.T) {
 	r := InsertRequest{}
 	// empty database
-	req, err := r.Build("", "")
+	req, err := r.Build(&Config{})
 	assert.Equal(t, ErrEmptyDatabase, err)
 	assert.Nil(t, req)
 
 	// empty table
 	r.Database = "public"
-	req, err = r.Build("", "")
+	req, err = r.Build(&Config{})
 	assert.Equal(t, ErrEmptyTable, err)
 	assert.Nil(t, req)
 
 	// empty series
 	r.WithTable("monitor")
-	req, err = r.Build("", "")
+	req, err = r.Build(&Config{})
 	assert.Equal(t, ErrNoSeriesInMetric, err)
 	assert.Nil(t, req)
 }

--- a/pkg/request/request_test.go
+++ b/pkg/request/request_test.go
@@ -8,17 +8,37 @@ import (
 
 func TestQueryBuilder(t *testing.T) {
 	rb := &QueryRequest{}
-	request, err := rb.Build()
+	request, err := rb.Build("", "")
 	assert.Nil(t, request)
 	assert.ErrorIs(t, err, ErrEmptyDatabase)
 
 	rb.WithDatabase("disk_usage")
-	request, err = rb.Build()
+	request, err = rb.Build("", "")
 	assert.Nil(t, request)
 	assert.ErrorIs(t, err, ErrEmptyQuery)
 
 	rb.WithSql("select * from monitor")
-	request, err = rb.Build()
+	request, err = rb.Build("", "")
 	assert.NotNil(t, request)
 	assert.Nil(t, err)
+}
+
+func TestInsertBuilder(t *testing.T) {
+	r := InsertRequest{}
+	// empty database
+	req, err := r.Build("", "")
+	assert.Equal(t, ErrEmptyDatabase, err)
+	assert.Nil(t, req)
+
+	// empty table
+	r.Database = "public"
+	req, err = r.Build("", "")
+	assert.Equal(t, ErrEmptyTable, err)
+	assert.Nil(t, req)
+
+	// empty series
+	r.WithTable("monitor")
+	req, err = r.Build("", "")
+	assert.Equal(t, ErrNoSeriesInMetric, err)
+	assert.Nil(t, req)
 }

--- a/pkg/request/stream_client.go
+++ b/pkg/request/stream_client.go
@@ -12,7 +12,7 @@ type StreamClient struct {
 }
 
 func (c *StreamClient) Send(ctx context.Context, req InsertRequest) error {
-	request, err := req.Build()
+	request, err := req.Build(c.cfg.Catalog, c.cfg.Database)
 	if err != nil {
 		return err
 	}

--- a/pkg/request/stream_client.go
+++ b/pkg/request/stream_client.go
@@ -12,7 +12,7 @@ type StreamClient struct {
 }
 
 func (c *StreamClient) Send(ctx context.Context, req InsertRequest) error {
-	request, err := req.Build(c.cfg.Catalog, c.cfg.Database)
+	request, err := req.Build(c.cfg)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## What's changed and what's your intention?

When initiating a `client`, users can set `Catalog` and `Database`. Afterwards, when building `request`, they can also set the two fields.

The former should be a default value: when `request` are not set with these field, use the ones in `client`'s config to execute.

## Checklist

- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
#51 