### PR TITLE
chore: rename Addr to Host in Config

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -40,7 +40,7 @@ type monitor struct {
 
 var (
 	database = "public"
-	addr     = "127.0.0.1"
+	host     = "127.0.0.1"
 	port     = 0
 )
 
@@ -104,7 +104,7 @@ func newClient(t *testing.T) *Client {
 	options := []grpc.DialOption{
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	}
-	cfg := NewCfg(addr).WithPort(port).WithDatabase(database).WithDialOptions(options...)
+	cfg := NewCfg(host).WithPort(port).WithDatabase(database).WithDialOptions(options...)
 	client, err := NewClient(cfg)
 	assert.Nil(t, err)
 	return client
@@ -116,12 +116,12 @@ func TestInvalidClient(t *testing.T) {
 		grpc.WithBlock(),
 		grpc.WithTimeout(time.Second),
 	}
-	cfg := NewCfg("invalid addr").WithPort(port).WithDatabase(database).WithDialOptions(options...)
+	cfg := NewCfg("invalid host").WithPort(port).WithDatabase(database).WithDialOptions(options...)
 	client, err := NewClient(cfg)
 	assert.Nil(t, client)
 	assert.NotNil(t, err)
 
-	cfg = NewCfg(addr).WithPort(1111).WithDatabase(database).WithDialOptions(options...)
+	cfg = NewCfg(host).WithPort(1111).WithDatabase(database).WithDialOptions(options...)
 	client, err = NewClient(cfg)
 	assert.Nil(t, client)
 	assert.NotNil(t, err)
@@ -320,7 +320,7 @@ func TestNoNeedAuth(t *testing.T) {
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	}
 	// Client can always connect to a no-auth database, even the usernames and passwords are wrong
-	cfg := NewCfg(addr).WithPort(port).WithDatabase(database).WithAuth("user", "pwd").WithDialOptions(options...)
+	cfg := NewCfg(host).WithPort(port).WithDatabase(database).WithAuth("user", "pwd").WithDialOptions(options...)
 	client, err := NewClient(cfg)
 	assert.Nil(t, err)
 

--- a/config.go
+++ b/config.go
@@ -23,9 +23,8 @@ import (
 
 // Config is to define how the Client behaves.
 //
-//   - Addr is 127.0.0.1 in local environment. You can find the address in
-//     the detail page if you create one service in GreptimeCloud
-//   - Port default value is 4001
+//   - Host is 127.0.0.1 in local environment.
+//   - Port default value is 4001.
 //   - Username and Password can be left to empty in local environment.
 //     you can find them in GreptimeCloud service detail page.
 //   - Database is the default database the client will operate on.
@@ -33,7 +32,7 @@ import (
 //   - DialOptions and CallOptions are for gRPC service.
 //     You can specify them or leave them empty.
 type Config struct {
-	Addr     string // example: 127.0.0.1
+	Host     string // example: 127.0.0.1
 	Port     int    // default: 4001
 	Username string
 	Password string
@@ -47,10 +46,10 @@ type Config struct {
 	CallOptions []grpc.CallOption
 }
 
-// NewCfg helps to init Config with addr only
-func NewCfg(addr string) *Config {
+// NewCfg helps to init Config with host only
+func NewCfg(host string) *Config {
 	return &Config{
-		Addr: addr,
+		Host: host,
 		Port: 4001,
 
 		DialOptions: []grpc.DialOption{
@@ -116,5 +115,5 @@ func (c *Config) BuildAuthHeader() *greptimepb.AuthHeader {
 }
 
 func (c *Config) getGRPCAddr() string {
-	return fmt.Sprintf("%s:%d", c.Addr, c.Port)
+	return fmt.Sprintf("%s:%d", c.Host, c.Port)
 }

--- a/promql_test.go
+++ b/promql_test.go
@@ -55,7 +55,7 @@ func TestInsertAndQueryWithRangePromQL(t *testing.T) {
 	options := []grpc.DialOption{
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	}
-	cfg := NewCfg(addr).WithPort(port).WithDatabase(database).WithDialOptions(options...)
+	cfg := NewCfg(host).WithPort(port).WithDatabase(database).WithDialOptions(options...)
 	client, err := NewClient(cfg)
 	assert.Nil(t, err)
 

--- a/stream_client_test.go
+++ b/stream_client_test.go
@@ -52,7 +52,7 @@ func TestStreamInsert(t *testing.T) {
 	options := []grpc.DialOption{
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	}
-	cfg := NewCfg(addr).WithPort(port).WithDatabase(database).WithDialOptions(options...).WithCallOptions()
+	cfg := NewCfg(host).WithPort(port).WithDatabase(database).WithDialOptions(options...).WithCallOptions()
 	streamClient, err := NewStreamClient(cfg)
 	assert.Nil(t, err)
 


### PR DESCRIPTION
## What's changed and what's your intention?

Rename Addr field to Host in Config
